### PR TITLE
Fix sanitizeUser and add user input sanitizer

### DIFF
--- a/backendValidation/Middleware/sanitized.js
+++ b/backendValidation/Middleware/sanitized.js
@@ -123,20 +123,24 @@ export function sanitizeUser(user){
   if(!user || typeof user !== 'object'){
     throw new Error('Invalid user object');
   }
+
   const sanitizedUser = {};
-  sanitizedUser.id = parseInt(user.id, 10);
-  if(isNaN(sanitizedUser.id)){
+  sanitizedUser.id = xss(String(user.id));
+  if(!sanitizedUser.id){
     throw new Error('Invalid user id');
   }
+
   sanitizedUser.name = xss(user.name);
   if(sanitizedUser.name.length > 30){
     throw new Error('Name is too long');
   }
-  //email format is u+take_number+@bsmch.net
+
   sanitizedUser.email = xss(user.email);
-  if(!sanitizedUser.email.match(/^u\d{1,7}@bsmch\.net$/)){
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if(!emailRegex.test(sanitizedUser.email)){
     throw new Error('Invalid email format');
   }
+
   return sanitizedUser;
 }
 

--- a/backendValidation/utils/sanitizeUserInput.js
+++ b/backendValidation/utils/sanitizeUserInput.js
@@ -1,0 +1,31 @@
+import xss from 'xss';
+
+export function sanitizeUserInput({ displayName, principalName, role }) {
+  if (!displayName || typeof displayName !== 'string') {
+    throw new Error('Invalid display name');
+  }
+  const sanitizedDisplay = xss(displayName);
+  if (sanitizedDisplay.length > 50) {
+    throw new Error('Display name is too long');
+  }
+
+  if (!principalName || typeof principalName !== 'string') {
+    throw new Error('Invalid email');
+  }
+  const sanitizedEmail = xss(principalName);
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(sanitizedEmail)) {
+    throw new Error('Invalid email');
+  }
+
+  if (!role || typeof role !== 'string') {
+    throw new Error('Invalid role');
+  }
+  const sanitizedRole = xss(role);
+
+  return {
+    display_name: sanitizedDisplay,
+    email: sanitizedEmail,
+    role: sanitizedRole,
+  };
+}


### PR DESCRIPTION
## Summary
- expand `sanitizeUser` to handle string IDs and general email formats
- add missing `sanitizeUserInput` helper used by auth flow

## Testing
- `npm run start` *(fails: Identifier 'getCurrentAzureAdmins' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_688b23daffdc8331862f99764e543444